### PR TITLE
factories method calls without parentheses

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -47,7 +47,7 @@ Style/Documentation:
 Style/DoubleNegation:
   Enabled: false
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
 Style/IfUnlessModifier:
   Enabled: false
 Style/MethodCallWithArgsParentheses:
@@ -57,6 +57,7 @@ Style/MethodCallWithArgsParentheses:
   - "**/schema.rb"
   - config.ru
   - Gemfile
+  - "**/factories/**/*_factory.rb"
   IgnoreMacros: true
   IgnoredMethods:
   - alias


### PR DESCRIPTION
Lets enable frozenstringliterals!
lets do not require MethodCallWithArgsParentheses inside factories (remember factries can be also inside engines)

```
  factory :status_update_params, class: Hash do
    transient do
      car_id 1
      tour_id 1
      message "enter"
```