### PR TITLE
Exclude schema.rb entirely

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2,6 +2,7 @@
 AllCops:
   DisplayCopNames: true
   Exclude:
+  - "**/schema.rb"
   - "**/vendor/**/*"
   - "**/vendor/**/.*"
 Bundler/OrderedGems:
@@ -54,7 +55,6 @@ Style/MethodCallWithArgsParentheses:
   Enabled: true
   Exclude:
   - "*.gemspec"
-  - "**/schema.rb"
   - config.ru
   - Gemfile
   - "**/factories/**/*_factory.rb"


### PR DESCRIPTION
`sequel-rails` adds whitespace so more cops are triggered here.