### PR TITLE
End aligment changes

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -7,6 +7,10 @@ AllCops:
   - "**/vendor/**/.*"
 Bundler/OrderedGems:
   Enabled: false
+Layout/CaseIndentation:
+  EnforcedStyle: end
+Layout/ElseAlignment:
+  Enabled: false
 Layout/IndentHash:
   EnforcedStyle: consistent
 Lint/AmbiguousOperator:
@@ -15,6 +19,8 @@ Lint/AmbiguousRegexpLiteral:
   Enabled: false
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
+Lint/EndAlignment:
+  EnforcedStyleAlignWith: variable
 Lint/HandleExceptions:
   Enabled: false
 Metrics/AbcSize:
@@ -46,6 +52,8 @@ Style/Alias:
 Style/Documentation:
   Enabled: false
 Style/DoubleNegation:
+  Enabled: false
+Style/EmptyCaseCondition:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: true


### PR DESCRIPTION
Previously, autocorrection turned this:

```ruby
test = if something
  "a"
else
  "b"
end
```

...into this:

```ruby
test = if something
            "a"
          else
            "b"
          end
```

which imo looks weierder than the original.

the original is now ok to use.

also this works (which I recommend):

```ruby
test = 
  if something
    "a"
  else
    "b"
  end
```

\+ added something to allow `case` statements without a condition. sometimes they're easier to read than an `if/elsif/elsif/elsif` sequence.