### PR TITLE
Disable SymbolArray

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -123,6 +123,8 @@ Style/RegexpLiteral:
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
+Style/SymbolArray:
+  Enabled: false
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
 Style/VariableNumber:


### PR DESCRIPTION
Enforcing this makes nested arrays look pretty ugly. The preference for `%(...)` over `%[...]` is still in place (because that's how we've been using it most of the times) but only if you use the `%` notation.