### PR TITLE
Disable RescueModifier cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -120,6 +120,8 @@ Style/RedundantException:
   Enabled: false
 Style/RegexpLiteral:
   Enabled: false
+Style/RescueModifier:
+  Enabled: false
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes


### PR DESCRIPTION
The short version is pretty neat sometimes:

```ruby
Stuff.create rescue Sequel::UniqueConstraintViolation
```