### PR TITLE
Whitelist include_context for parentheses.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -85,6 +85,7 @@ Style/MethodCallWithArgsParentheses:
   - fail
   - halt
   - include
+  - include_context
   - include_examples
   - it
   - it_behaves_like


### PR DESCRIPTION
Required by https://github.com/blacklane/elli/pull/3111