### PR TITLE
Allow `redirect_to` with no parentheses

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -99,6 +99,7 @@ Style/MethodCallWithArgsParentheses:
   - not_to
   - puts
   - raise
+  - redirect_to
   - render
   - require
   - require_relative


### PR DESCRIPTION
Since `render` is allowed, `redirect_to` should be as well
