### PR TITLE
Handle common RSpec idioms

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -14,6 +14,9 @@ Layout/ElseAlignment:
   Enabled: false
 Layout/IndentHash:
   EnforcedStyle: consistent
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+  - spec/**/*.rb
 Lint/AmbiguousOperator:
   Enabled: false
 Lint/AmbiguousRegexpLiteral:
@@ -28,10 +31,6 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
   Enabled: false
-ClassAndModuleChildren:
-  Exclude:
-  - spec/**/*.rb
-  - test/**/*.rb
 Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
@@ -50,6 +49,12 @@ Style/AccessorMethodName:
   Enabled: false
 Style/Alias:
   Enabled: false
+Style/BlockDelimiters:
+  EnforcedStyle: semantic
+Style/ClassAndModuleChildren:
+  Exclude:
+  - spec/**/*.rb
+  - test/**/*.rb
 Style/Documentation:
   Enabled: false
 Style/DoubleNegation:
@@ -59,7 +64,9 @@ Style/EmptyCaseCondition:
 Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:
-    - "**/migrate/*"
+  - spec/**/*.rb
+  - test/**/*.rb
+  - "**/migrate/*"
 Style/IfUnlessModifier:
   Enabled: false
 Style/ImplicitRuntimeError:


### PR DESCRIPTION
## AmbiguousBlockAssociation 

It tends to flag uses of:

```ruby
expect { block }.to change { another_block }
```

and rightly so, because generally, it's not clear that the argument to 'to' is `change { block }`. However, this is a common RSpec idiom, so best to disable it entirely for specs.

## ClassAndModuleChildren

Used old unprefixed name, renamed and moved to proper place

## BlockDelimiters

Changed to semantic mode. [Read the specs](https://github.com/bbatsov/rubocop/blob/master/spec/rubocop/cop/style/block_delimiters_spec.rb#L34) to see what's the difference.

## FrozenStringLiteralComments

Don't require them in specs.


