### PR TITLE
Semantic block delimiters proved too controversial

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -50,7 +50,10 @@ Style/AccessorMethodName:
 Style/Alias:
   Enabled: false
 Style/BlockDelimiters:
-  EnforcedStyle: semantic
+  EnforcedStyle: line_count_based # Explicitly, even if this is the default setting
+  Exclude:
+  - "**/spec/**/*.rb"
+  - "**/test/**/*.rb"
 Style/ClassAndModuleChildren:
   Exclude:
   - "**/spec/**/*.rb"


### PR DESCRIPTION
Restoring default `line_count_based`, but disabling for spec code.