### PR TITLE
Tolerate method calls without parens in Rakefiles (and Gemfiles)

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -80,6 +80,7 @@ Style/MethodCallWithArgsParentheses:
   - "**/config/routes/*.rb"
   - "**/factories/**/*_factory.rb"
   - "**/Gemfile"
+  - "**/Rakefile"
   - "**/migrate/*"
   - "*.gemspec"
   - config.ru

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -79,8 +79,8 @@ Style/MethodCallWithArgsParentheses:
   - "**/config/routes.rb"
   - "**/config/routes/*.rb"
   - "**/factories/**/*_factory.rb"
-  - "**/Gemfile"
-  - "**/Rakefile"
+  - "**/**/Gemfile"
+  - "**/**/Rakefile"
   - "**/migrate/*"
   - "*.gemspec"
   - config.ru


### PR DESCRIPTION
With glob paths so they match across all engines.