### PR TITLE
Exclude gemspec files

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -5,7 +5,8 @@ AllCops:
   - "**/schema.rb"
   - "**/vendor/**/*"
   - "**/vendor/**/.*"
-  - "bin/*"
+  - "**/bin/*"
+  - "**/*.gemspec"
 Bundler/OrderedGems:
   Enabled: false
 Layout/CaseIndentation:


### PR DESCRIPTION
These are mostly autogenerated and have their own DSL and conventions.