### PR TITLE
Add `before` to list of MethodCallWithArgsParentheses ignored

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -100,6 +100,7 @@ Style/MethodCallWithArgsParentheses:
   - attr_writer
   - attribute
   - attributes
+  - before
   - context
   - desc
   - describe


### PR DESCRIPTION
Because RSpec