### PR TITLE
Extend the methods list that excluded from MethodCallWithArgsParentheses cop.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -108,6 +108,7 @@ Style/MethodCallWithArgsParentheses:
   - describe
   - example
   - fail
+  - feature
   - Given
   - halt
   - include
@@ -129,12 +130,14 @@ Style/MethodCallWithArgsParentheses:
   - shared_context
   - should
   - should_not
+  - specify
   - task
   - Then
   - throw
   - to
   - to_not
   - use
+  - visit
   - When
   - xit
 Style/MutableConstant:


### PR DESCRIPTION
I'm suggesting a little bit extend the list of `MethodCallWithArgsParentheses` cop exclusions.
Suggesting those changes I would like to avoid the things like [this](https://github.com/blacklane/elli/pull/3958/files#diff-7e7a446e40a7f9d72c838ff89cdbe236R5), faced when trying to add new spec file.