### PR TITLE
[NO-TICKET] update to work with rubocop 0.55

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Usage
 
-The recommended version of [Rubocop](https://github.com/bbatsov/rubocop) to use is `0.49` or higher.
+The recommended version of [Rubocop](https://github.com/bbatsov/rubocop) to use is `0.55` or higher.
 
 Inside your project, add the `.rubocop.yml` file containing:
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -13,6 +13,8 @@ Layout/CaseIndentation:
   EnforcedStyle: end
 Layout/ElseAlignment:
   Enabled: false
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
 Layout/IndentHash:
   EnforcedStyle: consistent
 Lint/AmbiguousBlockAssociation:
@@ -24,8 +26,6 @@ Lint/AmbiguousRegexpLiteral:
   Enabled: false
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
-Lint/EndAlignment:
-  EnforcedStyleAlignWith: variable
 Lint/HandleExceptions:
   Enabled: false
 Metrics/AbcSize:
@@ -46,8 +46,10 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Enabled: false
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
 Style/Alias:
   Enabled: false
 Style/AsciiComments:
@@ -157,7 +159,5 @@ Style/SymbolArray:
   Enabled: false
 Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
-Style/VariableNumber:
-  EnforcedStyle: snake_case
 Style/WordArray:
   Enabled: false


### PR DESCRIPTION
fixing the
```
.rubocop-https---raw-githubusercontent-com-blacklane-rubocop-master-rubocop-yml: Lint/EndAlignment has the wrong namespace - should be Layout
.rubocop-https---raw-githubusercontent-com-blacklane-rubocop-master-rubocop-yml: Style/AccessorMethodName has the wrong namespace - should be Naming
.rubocop-https---raw-githubusercontent-com-blacklane-rubocop-master-rubocop-yml: Style/VariableNumber has the wrong namespace - should be Naming
```
warnings after update to 0.55