### PR TITLE
[NO-TICKET] add "and" and "or" on the whitelist, for Rspec

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -96,6 +96,7 @@ Style/MethodCallWithArgsParentheses:
   IgnoredMethods:
   - alias
   - alias_method
+  - and
   - And
   - attr_accessor
   - attr_reader
@@ -116,6 +117,7 @@ Style/MethodCallWithArgsParentheses:
   - it_behaves_like
   - it_should_behave_like
   - not_to
+  - or
   - puts
   - raise
   - redirect_back
@@ -132,8 +134,6 @@ Style/MethodCallWithArgsParentheses:
   - throw
   - to
   - to_not
-  - and
-  - or
   - use
   - When
   - xit

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -132,6 +132,8 @@ Style/MethodCallWithArgsParentheses:
   - throw
   - to
   - to_not
+  - and
+  - or
   - use
   - When
   - xit


### PR DESCRIPTION
Reason:
This snippet
```
expect { subject }
          .to change { EmiratesBookingInfo.count }
          .by(1)
          .and change { EmiratesBookingInfo.where(action: "edit").count }
          .by(1)
```
Throws this warning (140 is the 2nd line of the snippet)
`spec/services/emirates/action/edit_spec.rb:140 W: Style/MethodCallWithArgsParentheses: Use parentheses for method calls with arguments.`

Considering guidelines, this should be allowed.
https://relishapp.com/rspec/rspec-expectations/docs/compound-expectations