### PR TITLE
Configure 'Style/FormatStringToken' cop to enforce 'template' style.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -69,6 +69,8 @@ Style/DoubleNegation:
   Enabled: false
 Style/EmptyCaseCondition:
   Enabled: false
+Style/FormatStringToken:
+  EnforcedStyle: template
 Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:


### PR DESCRIPTION
Configure `Style/FormatStringToken` cop to enforce `template` style for named format string tokens
`format('%{greeting}', greeting: 'Hello')` instead of `format('%<greeting>s', greeting: 'Hello').
`