### PR TITLE
Updating IndentHash to IndentFirstHashElement

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -15,7 +15,7 @@ Layout/ElseAlignment:
   Enabled: false
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 Lint/AmbiguousBlockAssociation:
   Exclude:


### PR DESCRIPTION
Since version 0.68 rubucop updated `IndentHash` to `IndentFirstHashElement` see [here](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#changes-4).