### PR TITLE
rename rule Layout/IndentFirstHashElement fix

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -15,7 +15,7 @@ Layout/ElseAlignment:
   Enabled: false
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 Lint/AmbiguousBlockAssociation:
   Exclude:


### PR DESCRIPTION
Fix for more recent rubocop version